### PR TITLE
Crash wen using large textures

### DIFF
--- a/effects/butterfly-gears/Makefile
+++ b/effects/butterfly-gears/Makefile
@@ -11,8 +11,8 @@ CLEAN-FILES := \
 
 PNG2C.gears_testscreen := --bitmap testscreen,320x280x5 --palette testscreen_pal,32,+store_unused
 PNG2C.gears_testscreen_debug := --bitmap testscreen,320x280x5 --palette testscreen_pal,32,+store_unused
-PNG2C.texture_butterfly := --pixmap texture_butterfly,128x128x12
-PNG2C.texture_butterfly2 := --pixmap texture_butterfly2,128x128x12
+PNG2C.texture_butterfly := --pixmap texture_butterfly,128x256x12
+PNG2C.texture_butterfly2 := --pixmap texture_butterfly2,128x256x12
 
 include $(TOPDIR)/build.effect.mk
 

--- a/effects/butterfly-gears/data/texture_butterfly.png
+++ b/effects/butterfly-gears/data/texture_butterfly.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0a0a9f6e1c5409fdc2f40989129d4703739444d3ce8630b50c5d9a3d93a09c95
-size 35482
+oid sha256:2e836531a8926c5876de97881a016d8b88d586d35e6593bad4c85c24eaf5a7be
+size 68048

--- a/effects/butterfly-gears/data/texture_butterfly2.png
+++ b/effects/butterfly-gears/data/texture_butterfly2.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c491b4a4b7260ad55d6486b40c21455b9616d5f2acb8ac28297480b64d10ff92
-size 10549
+oid sha256:0a49af54027aee3b0fd060f19589871f0c815ad40ec3ec600d7e1cbd4b0c687e
+size 18023


### PR DESCRIPTION
Embedding two 128x256 textures leads to a Guru (00000004 illegal instruction).

Switching back to 128x128 works as expected.