### PR TITLE
Simple task synchronization scheme

### DIFF
--- a/include/task.h
+++ b/include/task.h
@@ -13,17 +13,27 @@ typedef TAILQ_HEAD(, Task) TaskListT;
 #define TS_BLOCKED 1   /* on blocked list */
 #define TS_SUSPENDED 2 /* doesn't belong to any list */
 
+/* Lower event bits map to hardware interrupts:
+ * - 13...0 coming from custom chipset,
+ * - 18...14 coming from CIA A,
+ * - 23...19 coming from CIA B.
+ * Upper 8 bits can be used by user to synchronize tasks.
+ *
+ * You can directly use INTF_* constant to specify events you're waiting for. */
+#define EVF_CUSTOM(x) (x)
+#define EVF_CIAA(x) ((x) << 14)
+#define EVF_CIAB(x) ((x) << 19)
+#define EVF_SWI(x) ((x) << 23)
+
 struct Task {
-  /* Points to task context pushed on top of the stack. */
-  void *currSP;
+  void *currSP; /* Points to task context pushed on top of the stack. */
   TAILQ_ENTRY(Task) node; /* Ready tasks are stored on ReadyList. */
-  u_char state;
-  u_char prio;
-  short intrNest;
-  struct {
-    void *lower; /* Lowest stack address. */
-    void *upper; /* Highest stack address. */
-  } stack;
+  u_char state;           /* Task state - one of TS_* constants. */
+  u_char prio;     /* Task priority - 0 is the highest, 255 is the lowest. */
+  short intrNest;  /* Interrupt disable nesting count. */
+  u_int eventMask; /* Events we're waiting for. */
+  void *stkLower;  /* Lowest stack address. */
+  void *stkUpper;  /* Highest stack address. */
   char name[MAX_TASK_NAME_SIZE]; /* Task name (limited in size) */
 };
 
@@ -36,6 +46,10 @@ void TaskResume(TaskT *tsk);
 void TaskResumeISR(TaskT *tsk);
 void TaskSuspend(TaskT *tsk);
 void TaskPrioritySet(TaskT *tsk, u_char prio);
+
+u_int TaskWait(TaskT *tsk, u_int eventMask);
+void TaskNotifyISR(u_int eventMask);
+void TaskNotify(u_int eventMask);
 
 static inline void TaskYield(void) { asm volatile("\ttrap\t#0\n"); }
 

--- a/include/task.h
+++ b/include/task.h
@@ -31,7 +31,7 @@ struct Task {
   u_char state;           /* Task state - one of TS_* constants. */
   u_char prio;     /* Task priority - 0 is the highest, 255 is the lowest. */
   short intrNest;  /* Interrupt disable nesting count. */
-  u_int eventMask; /* Events we're waiting for. */
+  u_int eventMask; /* Events we're waiting for - combination of EVF_* flags. */
   void *stkLower;  /* Lowest stack address. */
   void *stkUpper;  /* Highest stack address. */
   char name[MAX_TASK_NAME_SIZE]; /* Task name (limited in size) */
@@ -47,7 +47,7 @@ void TaskResumeISR(TaskT *tsk);
 void TaskSuspend(TaskT *tsk);
 void TaskPrioritySet(TaskT *tsk, u_char prio);
 
-u_int TaskWait(TaskT *tsk, u_int eventMask);
+u_int TaskWait(u_int eventMask);
 void TaskNotifyISR(u_int eventMask);
 void TaskNotify(u_int eventMask);
 

--- a/include/task.h
+++ b/include/task.h
@@ -29,11 +29,11 @@ struct Task {
   void *currSP; /* Points to task context pushed on top of the stack. */
   TAILQ_ENTRY(Task) node; /* Ready tasks are stored on ReadyList. */
   u_char state;           /* Task state - one of TS_* constants. */
-  u_char prio;     /* Task priority - 0 is the highest, 255 is the lowest. */
-  short intrNest;  /* Interrupt disable nesting count. */
-  u_int eventMask; /* Events we're waiting for - combination of EVF_* flags. */
-  void *stkLower;  /* Lowest stack address. */
-  void *stkUpper;  /* Highest stack address. */
+  u_char prio;    /* Task priority - 0 is the highest, 255 is the lowest. */
+  short intrNest; /* Interrupt disable nesting count. */
+  u_int eventSet; /* Events we're waiting for - combination of EVF_* flags. */
+  void *stkLower; /* Lowest stack address. */
+  void *stkUpper; /* Highest stack address. */
   char name[MAX_TASK_NAME_SIZE]; /* Task name (limited in size) */
 };
 
@@ -47,9 +47,9 @@ void TaskResumeISR(TaskT *tsk);
 void TaskSuspend(TaskT *tsk);
 void TaskPrioritySet(TaskT *tsk, u_char prio);
 
-u_int TaskWait(u_int eventMask);
-void TaskNotifyISR(u_int eventMask);
-void TaskNotify(u_int eventMask);
+u_int TaskWait(u_int eventSet);
+void TaskNotifyISR(u_int eventSet);
+void TaskNotify(u_int eventSet);
 
 static inline void TaskYield(void) { asm volatile("\ttrap\t#0\n"); }
 

--- a/loader/kernel/task.c
+++ b/loader/kernel/task.c
@@ -122,7 +122,7 @@ static void MaybePreempt(void) {
 
 void TaskResume(TaskT *tsk) {
   IntrDisable();
-  Assert(tsk->state != TS_READY);
+  Assert(tsk->state == TS_SUSPENDED);
   ReadyAdd(tsk);
   MaybePreempt();
   IntrEnable();

--- a/loader/kernel/task.c
+++ b/loader/kernel/task.c
@@ -27,8 +27,8 @@ void TaskInit(TaskT *tsk, const char *name, void *stkptr, u_int stksz) {
   bzero(tsk, sizeof(TaskT));
   strlcpy(tsk->name, name, MAX_TASK_NAME_SIZE);
   tsk->state = (tsk == CurrentTask) ? TS_READY : TS_SUSPENDED;
-  tsk->stack.lower = stkptr;
-  tsk->stack.upper = stkptr + stksz;
+  tsk->stkLower = stkptr;
+  tsk->stkUpper = stkptr + stksz;
 }
 
 /* When calling RTE the stack must look as follows:
@@ -53,7 +53,7 @@ void TaskInit(TaskT *tsk, const char *name, void *stkptr, u_int stksz) {
   { *--(u_short *)sp = (u_short)(v); }
 
 void TaskRun(TaskT *tsk, u_char prio, void (*fn)(void *), void *arg) {
-  void *sp = tsk->stack.upper;
+  void *sp = tsk->stkUpper;
 
   PushLong(0); /* last return address at the bottom of stack */
 


### PR DESCRIPTION
Synchronization will be organized around single list of blocked tasks `WaitQueue`. All tasks waiting for hardware interrupt or software event will be moved onto the list. Each task will have an event mask `u_int`, which will allow it to wait for more than one event at a time. `TaskNotify(event_mask)` procedure go over each task from the list and resume it provided `event_mask` will match task's mask. Designated bits in the mask will correspond to hardware events from custom chipset and CIAs, other will be purely software events (some of them tied to keyboard or mouse, etc.).