### PR TITLE
Speed up uvmap effect by 12%

### DIFF
--- a/effects/uvmap/Makefile
+++ b/effects/uvmap/Makefile
@@ -1,7 +1,7 @@
 TOPDIR := $(realpath ../..)
 
 CLEAN-FILES := data/texture-16-1.c data/gradient.c data/gradient.png \
-	       data/uvmap.c
+	       data/uvmap.c mainloop.o
 
 PNG2C.texture-16-1 := --pixmap texture,128x128x8 --palette texture_pal,16
 PNG2C.gradient := --pixmap gradient,16x16x12

--- a/effects/uvmap/data/gen-uvmap.py
+++ b/effects/uvmap/data/gen-uvmap.py
@@ -10,14 +10,14 @@ def scramble_cmap4(uvmap):
 
     i = 0
     while i < len(uvmap):
-        out.append(uvmap[i + 0])
-        out.append(uvmap[i + 1])
-        out.append(uvmap[i + 4])
-        out.append(uvmap[i + 5])
-        out.append(uvmap[i + 2])
-        out.append(uvmap[i + 3])
-        out.append(uvmap[i + 6])
-        out.append(uvmap[i + 7])
+        out.append(uvmap[i + 0] * 2)
+        out.append(uvmap[i + 1] * 2)
+        out.append(uvmap[i + 4] * 2)
+        out.append(uvmap[i + 5] * 2)
+        out.append(uvmap[i + 2] * 2)
+        out.append(uvmap[i + 3] * 2)
+        out.append(uvmap[i + 6] * 2)
+        out.append(uvmap[i + 7] * 2)
         i += 8
 
     return out

--- a/effects/uvmap/mainloop.asm
+++ b/effects/uvmap/mainloop.asm
@@ -1,9 +1,19 @@
         section ".text"
 
-                                ; cpu/bus cycles
-        move.w  $1111(a1),d0    ; 12/3
-        or.w    $2222(a2),d0    ; 12/3
-        move.b  $3333(a1),d0    ; 12/3
-        or.b    $4444(a2),d0    ; 12/3
-        move.w  d0,(a0)+        ; 8/2
-                                ; 14/3.5 per pixel  
+group   macro                   ; cpu/bus cycles
+        move.w  $1111(a1),\1    ; 12/3
+        or.w    $2222(a2),\1    ; 12/3
+        move.b  $3333(a1),\1    ; 12/3
+        or.b    $4444(a2),\1    ; 12/3
+        endm
+
+        group   d0
+        group   d1
+        group   d2
+        group   d3
+        group   d4
+        group   d5
+        group   d6
+        group   d7              ; 48*8/12*8
+        movem.w d0-d7,-(a0)     ; 8+4*8/8
+                                ; 13.25/3.25 per pixel

--- a/effects/uvmap/mainloop.asm
+++ b/effects/uvmap/mainloop.asm
@@ -1,8 +1,9 @@
         section ".text"
 
-        move.w  $1111(a1),d0   ; hi
-        or.w    $2222(a2),d0   ; lo
-        move.b  $3333(a1),d0   ; hi
-        or.b    $4444(a2),d0   ; lo
-        move.w  d0,(a0)+
-
+                                ; cpu/bus cycles
+        move.w  $1111(a1),d0    ; 12/3
+        or.w    $2222(a2),d0    ; 12/3
+        move.b  $3333(a1),d0    ; 12/3
+        or.b    $4444(a2),d0    ; 12/3
+        move.w  d0,(a0)+        ; 8/2
+                                ; 14/3.5 per pixel  

--- a/effects/uvmap/mainloop.asm
+++ b/effects/uvmap/mainloop.asm
@@ -1,0 +1,8 @@
+        section ".text"
+
+        move.w  $1111(a1),d0   ; hi
+        or.w    $2222(a2),d0   ; lo
+        move.b  $3333(a1),d0   ; hi
+        or.b    $4444(a2),d0   ; lo
+        move.w  d0,(a0)+
+

--- a/effects/uvmap/mainloop.asm
+++ b/effects/uvmap/mainloop.asm
@@ -7,6 +7,8 @@ group   macro                   ; cpu/bus cycles
         or.b    $4444(a2),\1    ; 12/3
         endm
 
+        movem.w d2-d7,-(sp)
+
         group   d0
         group   d1
         group   d2
@@ -17,3 +19,5 @@ group   macro                   ; cpu/bus cycles
         group   d7              ; 48*8/12*8
         movem.w d0-d7,-(a0)     ; 8+4*8/8
                                 ; 13.25/3.25 per pixel
+
+        movem.w (sp)+,d2-d7

--- a/effects/uvmap/uvmap.c
+++ b/effects/uvmap/uvmap.c
@@ -67,6 +67,8 @@ static void MakeUVMapRenderCode(void) {
    * [a b c d e f g h] => [a b e f c d g h] */
   short n = WIDTH * HEIGHT / 32;
 
+  *code++ = 0x48a7; *code++ = 0x3f00; /* movem.w d2-d7,-(sp) */
+
   while (n--) {
     short m;
 
@@ -85,6 +87,7 @@ static void MakeUVMapRenderCode(void) {
     *code++ = 0x48a0; *code++ = 0xff00; /* d0-d7,-(a0) */
   }
 
+  *code++ = 0x4c9f; *code++ = 0x00fc; /* movem.w (sp)+,d2-d7 */
   *code++ = 0x4e75; /* rts */
 }
 

--- a/effects/uvmap/uvmap.c
+++ b/effects/uvmap/uvmap.c
@@ -10,7 +10,7 @@
 #define DEPTH 4
 #define FULLPIXEL 1
 
-static u_char *textureHi, *textureLo;
+static u_short *textureHi, *textureLo;
 static BitmapT *screen[2];
 static u_short active = 0;
 static CopListT *cp;
@@ -22,29 +22,36 @@ static CopInsT *bplptr[DEPTH];
 
 #define UVMapRenderSize (WIDTH * HEIGHT / 2 * 10 + 2)
 void (*UVMapRender)(u_char *chunky asm("a0"),
-                    u_char *textureHi asm("a1"),
-                    u_char *textureLo asm("a2"));
+                    u_short *textureHi asm("a1"),
+                    u_short *textureLo asm("a2"));
+
+/* [0 0 0 0 a0 a1 a2 a3] => [a0 a1 0 0 a2 a3 0 0] x 2 */
+static u_short PixelHi[16] = {
+  0x0000, 0x0404, 0x0808, 0x0c0c, 0x4040, 0x4444, 0x4848, 0x4c4c,
+  0x8080, 0x8484, 0x8888, 0x8c8c, 0xc0c0, 0xc4c4, 0xc8c8, 0xcccc,
+};
+
+/* [0 0 0 0 b0 b1 b2 b3] => [ 0 0 b0 b1 0 0 b2 b3] x 2 */
+static u_short PixelLo[16] = {
+  0x0000, 0x0101, 0x0202, 0x0303, 0x1010, 0x1111, 0x1212, 0x1313, 
+  0x2020, 0x2121, 0x2222, 0x2323, 0x3030, 0x3131, 0x3232, 0x3333, 
+};
 
 static void PixmapToTexture(const PixmapT *image,
-                            void *imageHi, void *imageLo) 
+                            u_short *imageHi, u_short *imageLo) 
 {
-  u_int *data = image->pixels;
-  int size = image->width * image->height;
+  u_char *data = image->pixels;
+  short n = image->width * image->height;
   /* Extra halves for cheap texture motion. */
-  u_int *hi0 = imageHi;
-  u_int *hi1 = imageHi + size;
-  u_int *lo0 = imageLo;
-  u_int *lo1 = imageLo + size;
-  short n = size / 4;
-  register u_int m1 asm("d6") = 0x0c0c0c0c;
-  register u_int m2 asm("d7") = 0x03030303;
+  u_short *hi0 = imageHi;
+  u_short *hi1 = imageHi + n;
+  u_short *lo0 = imageLo;
+  u_short *lo1 = imageLo + n;
 
   while (--n >= 0) {
-    u_int c = *data++;
-    /* [0 0 0 0 a0 a1 a2 a3] => [a0 a1 0 0 a2 a3 0 0] */
-    u_int hi = ((c & m1) << 4) | ((c & m2) << 2);
-    /* [0 0 0 0 b0 b1 b2 b3] => [ 0 0 b0 b1 0 0 b2 b3] */
-    u_int lo = ((c & m1) << 2) | (c & m2);
+    int c = *data++;
+    u_short hi = PixelHi[c];
+    u_short lo = PixelLo[c];
     *hi0++ = hi;
     *hi1++ = hi;
     *lo0++ = lo;
@@ -55,15 +62,21 @@ static void PixmapToTexture(const PixmapT *image,
 static void MakeUVMapRenderCode(void) {
   u_short *code = (void *)UVMapRender;
   u_short *data = uvmap;
-  short n = WIDTH * HEIGHT / 2;
 
-  /* The map is pre-scrambled to avoid one c2p pass: [a B C d] => [a C B d] */
+  /* The map is pre-scrambled to avoid one c2p pass:
+   * [a b c d e f g h] => [a b e f c d g h] */
+  short n = WIDTH * HEIGHT / 4;
+
   while (n--) {
-    *code++ = 0x1029;  /* 1029 xxxx | move.b xxxx(a1),d0 */
+    *code++ = 0x3029;  /* 3029 xxxx | move.w xxxx(a1),d0 */
     *code++ = *data++;
-    *code++ = 0x802a;  /* 802a yyyy | or.b   yyyy(a2),d0 */
+    *code++ = 0x806a;  /* 806a yyyy | or.w   yyyy(a2),d0 */
     *code++ = *data++;
-    *code++ = 0x10c0;  /* 10c0      | move.b d0,(a0)+    */
+    *code++ = 0x1029;  /* 1029 wwww | move.b wwww(a1),d0 */
+    *code++ = *data++;
+    *code++ = 0x802a;  /* 802a zzzz | or.b   zzzz(a2),d0 */
+    *code++ = *data++;
+    *code++ = 0x30c0;  /* 30c0      | move.w d0,(a0)+    */
   }
 
   *code++ = 0x4e75; /* rts */
@@ -84,15 +97,27 @@ static void ChunkyToPlanar(void) {
   register void **bpl asm("a0") = c2p.bpl;
 
   /*
-   * Our chunky buffer of size (WIDTH/2, HEIGHT/2) is in bpl[0]. Each 16-bit
-   * word of chunky buffer stores four 4-bit pixels [a B c D] in scrambled
-   * format described below:
-   * 
-   * [a3 a2 C3 C2 a1 a0 C1 C0 b3 b2 D3 D2 b1 b0 D1 D0]
+   * Our chunky buffer of size (WIDTH/2, HEIGHT/2) is stored in bpl[0].
+   * Each 32-bit long word of chunky buffer contains eight 4-bit pixels
+   * [a b c d e f g h] in scrambled format described below.
+   * Please note that a_i is the i-th least significant bit of a.
    *
-   * Using blitter we stretch pixels to 2x1. Line doubling is performed using
-   * copper. Rendered bitmap will have size (WIDTH, HEIGHT/2, DEPTH) and will
-   * be placed in bpl[2] and bpl[3].
+   * [a0 a1 b0 b1 a2 a3 b2 b3 e0 e1 f0 f1 e2 e3 f2 f3
+   *  c0 c1 d0 d1 c2 c3 d2 d3 g0 g1 h0 h1 g2 g3 h2 h3]
+   *
+   * So not only pixels in the texture must be scrambled, but also consecutive
+   * bytes of input buffer i.e.: [a b] [e f] [c d] [g h] (see `gen-uvmap.py`).
+   *
+   * Chunky to planar is divided into two major steps:
+   * 
+   * Swap 4x2: in two consecutive 16-bit words swap diagonally two bits,
+   *           i.e. [b0 b1] <-> [c0 c1], [b2 b3] <-> [c2 c3].
+   * Expand 2x1: [x0 x1 ...] is translated into [x0 x0 ...] and [x1 x1 ...]
+   *             and copied to corresponding bitplanes, this step effectively
+   *             stretches pixels to 2x1.
+   *
+   * Line doubling is performed using copper. Rendered bitmap will have size
+   * (WIDTH, HEIGHT/2, DEPTH) and will be placed in bpl[2] and bpl[3].
    */
 
   switch (c2p.phase) {
@@ -236,8 +261,8 @@ static void Init(void) {
   UVMapRender = MemAlloc(UVMapRenderSize, MEMF_PUBLIC);
   MakeUVMapRenderCode();
 
-  textureHi = MemAlloc(texture.width * texture.height * 2, MEMF_PUBLIC);
-  textureLo = MemAlloc(texture.width * texture.height * 2, MEMF_PUBLIC);
+  textureHi = MemAlloc(texture.width * texture.height * 4, MEMF_PUBLIC);
+  textureLo = MemAlloc(texture.width * texture.height * 4, MEMF_PUBLIC);
   PixmapToTexture(&texture, textureHi, textureLo);
 
   EnableDMA(DMAF_BLITTER);
@@ -280,8 +305,8 @@ static void Render(void) {
   /* screen's bitplane #0 is used as a chunky buffer */
   ProfilerStart(UVMap);
   {
-    u_char *txtHi = textureHi + offset;
-    u_char *txtLo = textureLo + offset;
+    u_short *txtHi = textureHi + offset;
+    u_short *txtLo = textureLo + offset;
 
     (*UVMapRender)(screen[active]->planes[0], txtHi, txtLo);
   }


### PR DESCRIPTION
* change texture representation in memory
* unroll loop 8 times
* each loop iteration renders 4 pixels