### PR TITLE
Mutex synchronization primitive

### DIFF
--- a/include/debug.h
+++ b/include/debug.h
@@ -3,10 +3,10 @@
 
 /* When simulator is configured to enter debugger on illegal instructions,
  * this macro can be used to set breakpoints in your code. */
-#define BREAK() { asm volatile("\tillegal\n"); }
+#define BREAK() { asm volatile("illegal"); }
 
 /* Halt the processor by masking all interrupts and waiting for NMI. */
-#define HALT() { asm volatile("\tstop\t#0x2700\n"); }
+#define HALT() { asm volatile("stop #0x2700"); }
 
 /* Use whenever a program should generate a fatal error. This will break into
  * debugger for program inspection and stop instruction execution. */

--- a/include/system/cpu.h
+++ b/include/system/cpu.h
@@ -34,23 +34,23 @@ extern u_char CpuModel;
 
 /* Make the processor wait for interrupt. */
 static inline void CpuWait(void) {
-  asm volatile("\tstop\t#0x2000\n");
+  asm volatile("stop #0x2000");
 }
 
 /* Code running in task context executes with IPL set to 0. */
 static inline void CpuIntrDisable(void) {
-  asm volatile("\tor.w\t#0x0700,%sr\n");
+  asm volatile("or.w #0x0700,%sr");
 }
 
 static inline void CpuIntrEnable(void) {
-  asm volatile("\tand.w\t#0xf8ff,%sr\n");
+  asm volatile("and.w #0xf8ff,%sr");
 }
 
 /* Returns current interrupt priority level. Reads whole Status Register
  * (it's privileged instruction on 68010 and above). */
 static inline u_short GetIPL(void) {
   u_short sr;
-  asm volatile("\tmove.w\t%%sr,%0\n" : "=d"(sr));
+  asm volatile("move.w %%sr,%0" : "=d"(sr));
   return sr & SR_IM;
 }
 

--- a/include/system/debug.h
+++ b/include/system/debug.h
@@ -14,4 +14,14 @@ __noreturn void Panic(const char *format, ...)
   __attribute__ ((format (printf, 1, 2)));
 #endif
 
+#ifdef _SYSTEM
+#ifdef DEBUG
+#define Debug(fmt, ...) Log("[%s] " fmt "\n", __func__, __VA_ARGS__)
+#define Assume(e) Assert(e)
+#else
+#define Debug(fmt, ...) ((void)0)
+#define Assume(e) { if (!(e)) HALT(); }
+#endif
+#endif /* !_SYSTEM */
+
 #endif /* !__SYSTEM_DEBUG__ */

--- a/include/system/mutex.h
+++ b/include/system/mutex.h
@@ -1,0 +1,27 @@
+#ifndef __MUTEX_H__
+#define __MUTEX_H__
+
+#include <types.h>
+#include <system/queue.h>
+
+struct Task;
+
+typedef struct Mutex {
+  volatile struct Task *owner;
+  TAILQ_HEAD(, Task) waitList;
+} MutexT;
+
+static inline void MutexInit(MutexT *mtx) {
+  mtx->owner = NULL;
+  TAILQ_INIT(&mtx->waitList);
+}
+
+#define MUTEX(name)                                                            \
+  MutexT name = (MutexT) {                                                     \
+    .owner = NULL, .waitList = TAILQ_HEAD_INITIALIZER(name.waitList)           \
+  }
+
+void MutexLock(MutexT *mtx);
+void MutexUnlock(MutexT *mtx);
+
+#endif /* !__MUTEX_H__ */

--- a/include/system/task.h
+++ b/include/system/task.h
@@ -49,6 +49,10 @@ void TaskResumeISR(TaskT *tsk);
 void TaskSuspend(TaskT *tsk);
 void TaskPrioritySet(TaskT *tsk, u_char prio);
 
+#ifdef _TASK_PRIVATE
+void ReadyAdd(TaskT *tsk);
+#endif
+
 u_int TaskWait(u_int eventSet);
 void TaskNotifyISR(u_int eventSet);
 void TaskNotify(u_int eventSet);

--- a/include/system/task.h
+++ b/include/system/task.h
@@ -57,7 +57,7 @@ u_int TaskWait(u_int eventSet);
 void TaskNotifyISR(u_int eventSet);
 void TaskNotify(u_int eventSet);
 
-static inline void TaskYield(void) { asm volatile("\ttrap\t#0\n"); }
+static inline void TaskYield(void) { asm volatile("trap #0"); }
 
 /* Enable / disable all interrupts. Handle nested calls. */
 void IntrDisable(void);

--- a/system/Makefile
+++ b/system/Makefile
@@ -34,6 +34,7 @@ SOURCES := \
 	kernel/interrupt.c \
 	kernel/intr-entry.S \
 	kernel/memory.c \
+	kernel/mutex.c \
 	kernel/task.c \
 	kernel/trap-entry.S \
 	kernel/trap.c 

--- a/system/amigaos.c
+++ b/system/amigaos.c
@@ -7,6 +7,7 @@
 #include <hardware/intbits.h>
 #include <proto/alib.h>
 #include <proto/exec.h>
+#undef Debug
 #include <proto/graphics.h>
 
 #include <system/boot.h>

--- a/system/drivers/cia-timer.c
+++ b/system/drivers/cia-timer.c
@@ -51,7 +51,7 @@ CIATimerT *AcquireTimer(u_int num) {
   CIATimerT *timer = NULL;
   u_int i;
 
-  Assert(num <= TIMER_CIAB_B || num == TIMER_ANY);
+  Assume(num <= TIMER_CIAB_B || num == TIMER_ANY);
 
   MutexLock(&TimerMtx);
   /* Allocate a timer that is not in use and its' number matches
@@ -128,7 +128,7 @@ void WaitTimerGeneric(CIATimerT *timer, u_short delay, bool spin) {
       continue;
   } else {
     /* Must not sleep while in interrupt context! */
-    Assert(GetIPL() == 0);
+    Assume(GetIPL() == 0);
     /* Turn on the interrupt and go to sleep. */
     IntrDisable();
     timer->timeout = NotifyTimeout;

--- a/system/drivers/floppy.c
+++ b/system/drivers/floppy.c
@@ -7,8 +7,6 @@
 #include <system/task.h>
 #include <system/timer.h>
 
-#define DEBUG 0
-
 #define LOWER 0
 #define UPPER 1
 
@@ -179,9 +177,7 @@ void FloppyTrackRead(short num) {
   ClearIRQ(INTF_DSKBLK);
   EnableDMA(DMAF_DISK);
 
-#if DEBUG
-  Log("[Floppy] Read track %d.\n", num);
-#endif
+  Debug("[Floppy] Read track %d.\n", num);
 
   custom->dskpt = (void *)track;
   /* Write track size twice to initiate DMA transfer. */
@@ -229,11 +225,9 @@ void FloppyTrackDecode(u_int *buf) {
 
     *(u_int *)&info = DecodeLong(sector->info[0], sector->info[1], mask);
 
-#if DEBUG
-    Log("[Floppy] Decode: sector=%p, #sector=%d, #track=%d\n",
-        sector, info.sectorNum, info.trackNum);
-    Assert(info.sectorNum < NSECTORS && info.trackNum < NTRACKS);
-#endif
+    Debug("[Floppy] Decode: sector=%p, #sector=%d, #track=%d\n",
+          sector, info.sectorNum, info.trackNum);
+    Assume(info.sectorNum < NSECTORS && info.trackNum < NTRACKS);
 
     /* Decode sector! */
     {

--- a/system/drivers/serial.c
+++ b/system/drivers/serial.c
@@ -5,6 +5,7 @@
 #include <system/file.h>
 #include <system/interrupt.h>
 #include <system/memory.h>
+#include <system/mutex.h>
 #include <system/task.h>
 
 #define CLOCK 3546895
@@ -104,10 +105,12 @@ static FileOpsT SerialOps = {
   .close = SerialClose
 };
 
+static MUTEX(SerialMtx);
+
 FileT *SerialOpen(u_int baud, u_int flags) {
   static FileT *f = NULL;
 
-  IntrDisable();
+  MutexLock(&SerialMtx);
 
   if (f == NULL) {
     f = MemAlloc(sizeof(FileT), MEMF_PUBLIC|MEMF_CLEAR);
@@ -123,7 +126,7 @@ FileT *SerialOpen(u_int baud, u_int flags) {
     EnableINT(INTF_TBE | INTF_RBF);
   }
 
-  IntrEnable();
+  MutexUnlock(&SerialMtx);
 
   return f;
 }

--- a/system/kernel/interrupt.c
+++ b/system/kernel/interrupt.c
@@ -29,7 +29,7 @@ void RemIntServer(IntChainT *ic, IntServerT *is) {
   is_p = &ic->head;
   while (*is_p != is)
     is_p = &(*is_p)->next;
-  Assert(is_p != NULL);
+  Assume(is_p != NULL);
   *is_p = is->next;
   /* If the list is empty after removal then disable the interrupt. */
   if (!ic->head) {

--- a/system/kernel/memory.c
+++ b/system/kernel/memory.c
@@ -8,14 +8,6 @@
 #include <system/mutex.h>
 #include <system/task.h>
 
-#define DEBUG 0
-
-#if DEBUG
-#define Debug(fmt, ...) Log("%s: " fmt "\n", __func__, __VA_ARGS__)
-#else
-#define Debug(fmt, ...) ((void)0)
-#endif
-
 static MUTEX(MemMtx);
 
 typedef uintptr_t WordT;
@@ -207,7 +199,7 @@ void AddMemory(void *ptr, u_int size, u_int attributes) {
   u_int sz = (uintptr_t)end - (uintptr_t)ar->start;
   WordT *bt = ar->start;
 
-  Assert(end > (void *)ar->start + FREEBLK_SZ);
+  Assume(end > (void *)ar->start + FREEBLK_SZ);
 
   ar->succ = NULL;
   Head(ar)->prev = Head(ar);
@@ -277,7 +269,7 @@ static void ArenaMemFree(ArenaT *ar, void *ptr) {
 
   bt = BtFromPtr(ptr);
 
-  Assert(BtUsed(bt) && BtHasCanary(bt)); /* Is block free and has canary? */
+  Assume(BtUsed(bt) && BtHasCanary(bt)); /* Is block free and has canary? */
 
   /* Mark block as free. */
   memsz = BtSize(bt) - USEDBLK_SZ;
@@ -393,28 +385,28 @@ static void ArenaCheck(ArenaT *ar, int verbose) {
         BtSize(bt), " *"[is_last]);
     if (BtFree(bt)) {
       WordT *ft = BtFooter(bt);
-      Assert(*bt == *ft); /* Header and footer do not match? */
-      Assert(!prevfree); /* Free block not coalesced? */
+      Assume(*bt == *ft); /* Header and footer do not match? */
+      Assume(!prevfree); /* Free block not coalesced? */
       prevfree = 1;
       freeMem += BtSize(bt) - USEDBLK_SZ;
       dangling++;
     } else {
-      Assert(flag == prevfree); /* PREVFREE flag mismatch? */
-      Assert(BtHasCanary(bt)); /* Canary damaged? */
+      Assume(flag == prevfree); /* PREVFREE flag mismatch? */
+      Assume(BtHasCanary(bt)); /* Canary damaged? */
       prevfree = 0;
     }
   }
 
-  Assert(BtGetIsLast(prev)); /* Last block set incorrectly? */
-  Assert(freeMem == ar->totalFree); /* Total free memory miscalculated? */
+  Assume(BtGetIsLast(prev)); /* Last block set incorrectly? */
+  Assume(freeMem == ar->totalFree); /* Total free memory miscalculated? */
 
   for (n = Head(ar)->next; n != Head(ar); n = n->next) {
     WordT *bt = BtFromPtr(n);
-    Assert(BtFree(bt));
+    Assume(BtFree(bt));
     dangling--;
   }
 
-  Assert(dangling == 0 && "Dangling free blocks!");
+  Assume(dangling == 0 && "Dangling free blocks!");
 
   MutexUnlock(&MemMtx);
 }
@@ -424,7 +416,7 @@ static ArenaT *ArenaOf(void *ptr) {
   for (ar = FirstArena; ar != NULL; ar = ar->succ)
     if (ptr >= (void *)ar->start && ptr < (void *)ar->end)
       break;
-  Assert(ar != NULL);
+  Assume(ar != NULL);
   return ar;
 }
 

--- a/system/kernel/mutex.c
+++ b/system/kernel/mutex.c
@@ -18,8 +18,7 @@ void MutexLock(MutexT *mtx) {
 void MutexUnlock(MutexT *mtx) {
   TaskT *tsk;
   IntrDisable();
-  if (mtx->owner != CurrentTask)
-    PANIC();
+  Assume(mtx->owner == CurrentTask);
   mtx->owner = NULL;
   if ((tsk = TAILQ_FIRST(&mtx->waitList))) {
     TAILQ_REMOVE(&mtx->waitList, tsk, node);

--- a/system/kernel/mutex.c
+++ b/system/kernel/mutex.c
@@ -1,0 +1,29 @@
+#include <debug.h>
+#include <system/mutex.h>
+#define _TASK_PRIVATE
+#include <system/task.h>
+
+void MutexLock(MutexT *mtx) {
+  TaskT *tsk = CurrentTask;
+  IntrDisable();
+  while (mtx->owner) {
+    tsk->state = TS_BLOCKED;
+    TAILQ_INSERT_TAIL(&mtx->waitList, tsk, node);
+    TaskYield();
+  }
+  mtx->owner = tsk;
+  IntrEnable();
+}
+
+void MutexUnlock(MutexT *mtx) {
+  TaskT *tsk;
+  IntrDisable();
+  if (mtx->owner != CurrentTask)
+    PANIC();
+  mtx->owner = NULL;
+  if ((tsk = TAILQ_FIRST(&mtx->waitList))) {
+    TAILQ_REMOVE(&mtx->waitList, tsk, node);
+    ReadyAdd(tsk);
+  }
+  IntrEnable();
+}

--- a/system/kernel/task.c
+++ b/system/kernel/task.c
@@ -4,14 +4,6 @@
 #include <system/cpu.h>
 #include <system/task.h>
 
-#define DEBUG 0
-
-#if DEBUG
-#define Debug(fmt, ...) Log("[%s] " fmt "\n", __func__, __VA_ARGS__)
-#else
-#define Debug(fmt, ...) ((void)0)
-#endif
-
 static TaskT MainTask;
 TaskT *CurrentTask = &MainTask;
 
@@ -20,7 +12,7 @@ static TaskListT WaitList = TAILQ_HEAD_INITIALIZER(WaitList);
 u_char NeedReschedule = 0;
 
 void IntrEnable(void) {
-  Assert(CurrentTask->intrNest > 0);
+  Assume(CurrentTask->intrNest > 0);
   if (--CurrentTask->intrNest == 0)
     CpuIntrEnable();
 }
@@ -96,7 +88,7 @@ void ReadyAdd(TaskT *tsk) {
 /* Take a task with highest priority. */
 static TaskT *ReadyChoose(void) {
   TaskT *tsk;
-  Assert(GetIPL() == IPL_MAX);
+  Assume(GetIPL() == IPL_MAX);
   tsk = TAILQ_FIRST(&ReadyList);
   if (tsk != NULL)
     TAILQ_REMOVE(&ReadyList, tsk, node);
@@ -116,8 +108,8 @@ static void MaybePreemptISR(void) {
 
 void TaskResumeISR(TaskT *tsk) {
   u_short ipl = SetIPL(SR_IM);
-  Assert(ipl > IPL_NONE);
-  Assert(tsk->state == TS_SUSPENDED);
+  Assume(ipl > IPL_NONE);
+  Assume(tsk->state == TS_SUSPENDED);
   ReadyAdd(tsk);
   MaybePreemptISR();
   (void)SetIPL(ipl);
@@ -136,7 +128,7 @@ static void MaybePreempt(void) {
 
 void TaskResume(TaskT *tsk) {
   IntrDisable();
-  Assert(tsk->state == TS_SUSPENDED);
+  Assume(tsk->state == TS_SUSPENDED);
   ReadyAdd(tsk);
   MaybePreempt();
   IntrEnable();
@@ -144,7 +136,7 @@ void TaskResume(TaskT *tsk) {
 
 void TaskSuspend(TaskT *tsk) {
   IntrDisable();
-  Assert(tsk->state == TS_READY);
+  Assume(tsk->state == TS_READY);
   if (tsk != NULL) {
     TAILQ_REMOVE(&ReadyList, tsk, node);
     tsk->state = TS_SUSPENDED;
@@ -159,7 +151,7 @@ void TaskSuspend(TaskT *tsk) {
 void TaskPrioritySet(TaskT *tsk, u_char prio) {
   IntrDisable();
   if (tsk != NULL) {
-    Assert(tsk->state == TS_READY);
+    Assume(tsk->state == TS_READY);
     TAILQ_REMOVE(&ReadyList, tsk, node);
   } else {
     tsk = CurrentTask;
@@ -172,7 +164,7 @@ void TaskPrioritySet(TaskT *tsk, u_char prio) {
 
 u_int TaskWait(u_int eventSet) {
   TaskT *tsk = CurrentTask;
-  Assert(eventSet != 0);
+  Assume(eventSet != 0);
   IntrDisable();
   tsk->eventSet = eventSet;
   tsk->state = TS_BLOCKED;
@@ -188,7 +180,7 @@ u_int TaskWait(u_int eventSet) {
 static int _TaskNotify(u_int eventSet) {
   TaskT *tsk;
   int ntasks = 0;
-  Assert(eventSet != 0);
+  Assume(eventSet != 0);
   TAILQ_FOREACH(tsk, &WaitList, node) {
     if (tsk->eventSet & eventSet) {
       Debug("Waking up '%s' task waiting on $%08x (got $%08x).",
@@ -199,20 +191,20 @@ static int _TaskNotify(u_int eventSet) {
     }
   }
   if (ntasks == 0)
-    Log("[TaskNotify] Nobody was waiting for %08x events!\n", eventSet);
+    Debug("[TaskNotify] Nobody was waiting for %08x events!\n", eventSet);
   return ntasks;
 }
 
 void TaskNotifyISR(u_int eventSet) {
   u_short ipl = SetIPL(SR_IM);
-  Assert(ipl > IPL_NONE);
+  Assume(ipl > IPL_NONE);
   if (_TaskNotify(eventSet))
     MaybePreemptISR();
   (void)SetIPL(ipl);
 }
 
 void TaskNotify(u_int eventSet) {
-  Assert(GetIPL() == IPL_NONE);
+  Assume(GetIPL() == IPL_NONE);
   IntrDisable();
   if (_TaskNotify(eventSet))
     MaybePreempt();
@@ -220,8 +212,8 @@ void TaskNotify(u_int eventSet) {
 }
 
 void TaskSwitch(TaskT *curtsk) {
-  Assert(GetIPL() == IPL_MAX);
-  Assert(curtsk != NULL);
+  Assume(GetIPL() == IPL_MAX);
+  Assume(curtsk != NULL);
   if (curtsk->state == TS_READY)
     ReadyAdd(curtsk);
   while (!(curtsk = ReadyChoose())) {

--- a/system/kernel/task.c
+++ b/system/kernel/task.c
@@ -80,7 +80,7 @@ void TaskRun(TaskT *tsk, u_char prio, void (*fn)(void *), void *arg) {
   TaskResume(tsk);
 }
 
-static void ReadyAdd(TaskT *tsk) {
+void ReadyAdd(TaskT *tsk) {
   TaskT *before = TAILQ_FIRST(&ReadyList);
   /* Insert before first task with lower priority.
    * Please note that 0 is the highest priority! */


### PR DESCRIPTION
Mutexes are used to synchronize threads. Critical section created with a mutex is preemptible, so that other unrelated thread may interrupt its execution. This is primarily needed for memory allocator, but there are other use cases as well.