### PR TITLE
Handle read-only filesystem in a unified way

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ gdb-dashboard
 
 # executable files, floppy & rom images and archives
 *.adf
+*.img
 *.exe
 *.exe.dbg
 *.exe.map

--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,11 @@ SUBDIRS = tools lib system effects
 EXTRA-FILES = tags cscope.out
 CLEAN-FILES = bootloader.bin 
 
-all: bootloader.bin build
+all: a500rom.bin bootloader.bin build
 
 include $(TOPDIR)/build/common.mk
 
+a500rom.bin: ASFLAGS += -phxass
 bootloader.bin: ASFLAGS += -phxass
 
 FILES := $(shell find include lib system -type f -iname '*.[ch]')

--- a/a500rom.asm
+++ b/a500rom.asm
@@ -21,6 +21,11 @@ Kickstart:
         dc.l    $400             ; Initial SP
         dc.l    Entry            ; Initial PC
 
+HunkFilePtr:
+        dc.l    0
+HunkFileSize:
+        dc.l    0
+
 ; The ROM is located at $fc0000 but is mapped at $0 after reset shadowing RAM
 Entry:
         lea     ciaa,a4
@@ -44,8 +49,8 @@ InitHW:
         clr.b   ciatodlow(a5)
 
 Setup:
-        move.l  #(HunkFileEnd-HunkFile),d2
-        move.l  #HunkFile,d3
+        move.l  HunkFileSize(pc),d2
+        move.l  HunkFilePtr(pc),d3
         move.l  #BD_SIZE+2*MR_SIZE,a3
         sub.l   a3,sp
         move.l  sp,a6
@@ -64,15 +69,7 @@ Setup:
         move.w  #MEMF_CHIP|MEMF_PUBLIC,(a0)+
 
 ROM = 1
-        include '$(TOPDIR)/bootloader.asm'
 
-HunkFile
-        incbin  '$(EFFECT).exe'
-HunkFileEnd
-
-        org     $fffff0
-
-        dc.w    $4718, $4819, $4f1a, $531b
-        dc.w    $541c, $4f1d, $571e, $4e1f
+        include 'bootloader.asm'
 
 ; vim: ft=asm68k:ts=8:sw=8:noet:

--- a/build/common.mk
+++ b/build/common.mk
@@ -44,6 +44,7 @@ CP := cp -a
 RM := rm -v -f
 PYTHON3 := PYTHONPATH="$(TOPDIR)/tools/pylib:$$PYTHONPATH" python3
 ADFUTIL := $(TOPDIR)/tools/adfutil.py
+ROMUTIL := $(TOPDIR)/tools/romutil.py
 FSUTIL := $(TOPDIR)/tools/fsutil.py
 BINPATCH := $(TOPDIR)/tools/binpatch.py
 LAUNCH := $(PYTHON3) $(TOPDIR)/tools/launch.py

--- a/build/common.mk
+++ b/build/common.mk
@@ -43,6 +43,7 @@ endif
 CP := cp -a
 RM := rm -v -f
 PYTHON3 := PYTHONPATH="$(TOPDIR)/tools/pylib:$$PYTHONPATH" python3
+ADFUTIL := $(TOPDIR)/tools/adfutil.py
 FSUTIL := $(TOPDIR)/tools/fsutil.py
 BINPATCH := $(TOPDIR)/tools/binpatch.py
 LAUNCH := $(PYTHON3) $(TOPDIR)/tools/launch.py

--- a/build/effect.mk
+++ b/build/effect.mk
@@ -10,9 +10,10 @@ LDEXTRA += $(foreach lib,$(LIBS),$(TOPDIR)/lib/$(lib)/$(lib).a)
 
 CRT0 = $(TOPDIR)/system/crt0.o
 BOOTLOADER = $(TOPDIR)/bootloader.bin
+ROMSTARTUP = $(TOPDIR)/a500rom.bin
 
-EXTRA-FILES += $(DATA_GEN) $(EFFECT).exe $(EFFECT).adf $(EFFECT).rom
-CLEAN-FILES += $(DATA_GEN) $(EFFECT).exe.dbg $(EFFECT).exe.map 
+EXTRA-FILES += $(DATA_GEN) $(EFFECT).img $(EFFECT).adf $(EFFECT).rom
+CLEAN-FILES += $(DATA_GEN) $(EFFECT).exe $(EFFECT).exe.dbg $(EFFECT).exe.map 
 
 all: build
 
@@ -41,16 +42,6 @@ $(EFFECT).exe.dbg $(EFFECT).exe: $(CRT0) $(OBJECTS) $(LDEXTRA)
 	$(CP) $@ $@.dbg
 	$(STRIP) $@
 
-%.rom.asm: $(TOPDIR)/a500rom.asm $(TOPDIR)/bootloader.asm
-	@echo "[SED] $(notdir $^) -> $(DIR)$@"
-	sed -e 's,$$(TOPDIR),$(TOPDIR),g' \
-	    -e 's,$$(EFFECT),$(EFFECT),g' \
-	    $(TOPDIR)/a500rom.asm > $@ || (rm -f $@ && exit 1)
-
-%.rom: %.rom.asm %.exe
-	@echo "[VASM] $(addprefix $(DIR),$^) -> $(DIR)$@"
-	$(VASM) -Fbin $(VASMFLAGS) -o $@ $<
-
 data/%.c: data/%.lwo
 	@echo "[LWO] $(DIR)$< -> $(DIR)$@"
 	$(LWO2C) $(LWO2C.$*) -f $< $@
@@ -78,6 +69,10 @@ data/%.c: data/%.sync
 %.adf: %.img $(BOOTLOADER) 
 	@echo "[ADF] $(DIR)$< -> $(DIR)$@"
 	$(ADFUTIL) -b $(BOOTLOADER) $< $@ 
+
+%.rom: %.img $(ROMSTARTUP)
+	@echo "[ROM] $(DIR)$< -> $(DIR)$@"
+	$(ROMUTIL) $(ROMSTARTUP) $< $@ 
 
 # Default debugger - can be changed by passing DEBUGGER=xyz to make.
 DEBUGGER ?= gdb

--- a/build/effect.mk
+++ b/build/effect.mk
@@ -71,9 +71,13 @@ data/%.c: data/%.sync
 	@echo "[SYNC] $(DIR)$< -> $(DIR)$@"
 	$(SYNC2C) $(SYNC2C.$*) $< > $@ || (rm -f $@ && exit 1)
 
-%.adf: %.exe $(DATA) $(DATA_GEN) $(BOOTLOADER)
-	@echo "[ADF] $(addprefix $(DIR),$*.exe $(DATA) $(DATA_GEN)) -> $(DIR)$@"
-	$(FSUTIL) -b $(BOOTLOADER) create $@ $(filter-out %bootloader.bin,$^)
+%.img: %.exe $(DATA) $(DATA_GEN)
+	@echo "[IMG] $(addprefix $(DIR),$*.exe $(DATA) $(DATA_GEN)) -> $(DIR)$@"
+	$(FSUTIL) create $@ $(filter-out %bootloader.bin,$^)
+
+%.adf: %.img $(BOOTLOADER) 
+	@echo "[ADF] $(DIR)$< -> $(DIR)$@"
+	$(ADFUTIL) -b $(BOOTLOADER) $< $@ 
 
 # Default debugger - can be changed by passing DEBUGGER=xyz to make.
 DEBUGGER ?= gdb
@@ -91,4 +95,4 @@ debug: $(EFFECT).rom $(EFFECT).exe.dbg $(EFFECT).adf
 	$(LAUNCH) -d $(DEBUGGER) -r $(EFFECT).rom -e $(EFFECT).exe.dbg -f $(EFFECT).adf
 
 .PHONY: run debug run-floppy debug-floppy
-.PRECIOUS: $(BOOTLOADER)
+.PRECIOUS: $(BOOTLOADER) $(EFFECT).img

--- a/tools/adfutil.py
+++ b/tools/adfutil.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+
+import argparse
+import os
+from array import array
+from struct import pack
+from io import BytesIO
+
+from fsutil import SECTOR, align, write_pad, sectors, Filesystem
+
+#
+# On disk format description:
+#
+# sector 0..1: bootblock
+#  [LONG] 'DOS\0'
+#  [LONG] checksum
+#  [LONG] size of executable file aligned to sector size (takes m sectors)
+#  ...    boot code
+#
+# sector 2..: file system image
+
+FLOPPY = SECTOR * 80 * 11 * 2
+
+
+def checksum(data):
+    arr = array('I', data)
+    arr.byteswap()
+    chksum = sum(arr)
+    chksum = (chksum >> 32) + (chksum & 0xffffffff)
+    return (~chksum & 0xffffffff)
+
+
+def bootcode(path):
+    # Collect boot code if there's any...
+    if path is None:
+        return ''
+
+    if not os.path.isfile(path):
+        raise SystemExit('Boot code file does not exists!')
+
+    with open(path, 'rb') as fh:
+        bootcode = fh.read()
+    if len(bootcode) > 2 * SECTOR:
+        raise SystemExit('Boot code is larger than 1024 bytes!')
+    return bootcode
+
+
+def find_exec(img):
+    with open(img, 'rb') as fs:
+        for entry in Filesystem.load(fs):
+            if entry.exe:
+                return entry
+
+    return None
+
+
+def write_bb(adf, bootcode, exe):
+    boot = BytesIO(bootcode)
+    # Overwrite boot block header
+    exe_start = sectors(exe.offset)
+    exe_length = sectors(exe.size)
+    boot.write(pack('>4s4xHH', b'DOS\0', exe_length * 2, exe_start * 2))
+    # Move to the end and pad it so it takes 2 sectors
+    boot.seek(0, os.SEEK_END)
+    write_pad(boot, 2 * SECTOR)
+    # Calculate checksum and fill missing field in boot block
+    val = checksum(boot.getvalue())
+    boot.seek(4, os.SEEK_SET)
+    boot.write(pack('>I', val))
+    # Write fixed boot block to file system image
+    adf.write(boot.getvalue())
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description='Create ADF file from file system image.')
+    parser.add_argument(
+        '-b', '--bootcode', metavar='BOOTCODE', type=str,
+        help='Code to be put into boot block')
+    parser.add_argument(
+        'image', metavar='IMAGE', type=str,
+        help='File system image file')
+    parser.add_argument(
+        'adf', metavar='ADF', type=str,
+        help='ADF output file')
+    args = parser.parse_args()
+
+    bootblock = bootcode(args.bootcode)
+    executable = None
+
+    if bootblock:
+        executable = find_exec(args.image)
+        if not executable:
+            raise SystemExit('No AmigaHunk executable found!')
+
+    with open(args.adf, 'wb') as adf:
+        if bootblock:
+            write_bb(adf, bootblock, executable)
+
+        # Write file system image
+        with open(args.image, 'rb') as img:
+            adf.write(img.read())
+
+        # Complete floppy disk image
+        write_pad(adf, FLOPPY)

--- a/tools/adfutil.py
+++ b/tools/adfutil.py
@@ -14,7 +14,8 @@ from fsutil import SECTOR, align, write_pad, sectors, Filesystem
 # sector 0..1: bootblock
 #  [LONG] 'DOS\0'
 #  [LONG] checksum
-#  [LONG] size of executable file aligned to sector size (takes m sectors)
+#  [WORD] start of executable file, sector aligned, shifted right by 8
+#  [WORD] offset of executable file, sector aligned, shifte right by 8
 #  ...    boot code
 #
 # sector 2..: file system image

--- a/tools/adfutil.py
+++ b/tools/adfutil.py
@@ -32,21 +32,6 @@ def checksum(data):
     return (~chksum & 0xffffffff)
 
 
-def bootcode(path):
-    # Collect boot code if there's any...
-    if path is None:
-        return ''
-
-    if not os.path.isfile(path):
-        raise SystemExit('Boot code file does not exists!')
-
-    with open(path, 'rb') as fh:
-        bootcode = fh.read()
-    if len(bootcode) > 2 * SECTOR:
-        raise SystemExit('Boot code is larger than 1024 bytes!')
-    return bootcode
-
-
 def write_bb(adf, bootcode, exe):
     boot = BytesIO(bootcode)
     # Overwrite boot block header
@@ -78,10 +63,17 @@ if __name__ == '__main__':
         help='ADF output file')
     args = parser.parse_args()
 
-    bootblock = bootcode(args.bootcode)
+    bootblock = ''
     executable = None
 
-    if bootblock:
+    if args.bootcode:
+        if not os.path.isfile(args.bootcode):
+            raise SystemExit('Boot code file does not exists!')
+        if os.path.getsize(args.bootcode) > 2 * SECTOR:
+            raise SystemExit('Boot code is larger than 1024 bytes!')
+        with open(args.bootcode, 'rb') as fh:
+            bootblock = fh.read()
+
         executable = Filesystem.find_exec(args.image)
         if not executable:
             raise SystemExit('No AmigaHunk executable found!')

--- a/tools/adfutil.py
+++ b/tools/adfutil.py
@@ -6,7 +6,7 @@ from array import array
 from struct import pack
 from io import BytesIO
 
-from fsutil import SECTOR, align, write_pad, sectors, Filesystem
+from fsutil import SECTOR, write_pad, sectors, Filesystem
 
 #
 # On disk format description:
@@ -19,6 +19,7 @@ from fsutil import SECTOR, align, write_pad, sectors, Filesystem
 #  ...    boot code
 #
 # sector 2..: file system image
+#
 
 FLOPPY = SECTOR * 80 * 11 * 2
 
@@ -44,15 +45,6 @@ def bootcode(path):
     if len(bootcode) > 2 * SECTOR:
         raise SystemExit('Boot code is larger than 1024 bytes!')
     return bootcode
-
-
-def find_exec(img):
-    with open(img, 'rb') as fs:
-        for entry in Filesystem.load(fs):
-            if entry.exe:
-                return entry
-
-    return None
 
 
 def write_bb(adf, bootcode, exe):
@@ -90,7 +82,7 @@ if __name__ == '__main__':
     executable = None
 
     if bootblock:
-        executable = find_exec(args.image)
+        executable = Filesystem.find_exec(args.image)
         if not executable:
             raise SystemExit('No AmigaHunk executable found!')
 

--- a/tools/fsutil.py
+++ b/tools/fsutil.py
@@ -21,10 +21,7 @@ from io import BytesIO
 #   [LONG] #length : size of the file in bytes (up to 1MiB)
 #   [STRING] #name : name of the file (NUL terminated)
 #
-# sector (n)..(n+m-1): executable file in AmigaHunk format
-#  the file is assumed to be first in the directory
-#
-# sector (m+n)..: other files
+# sector (n)..(n+k-1): content of files
 #
 
 SECTOR = 512

--- a/tools/fsutil.py
+++ b/tools/fsutil.py
@@ -140,6 +140,15 @@ class Filesystem(UserList):
                 fh.write(entry.data)
                 write_pad(fh)
 
+    @classmethod
+    def find_exec(cls, path):
+        with open(path, 'rb') as fs:
+            for entry in cls.load(fs):
+                if entry.exe:
+                    return entry
+
+        return None
+
 
 def extract(archive, patterns, force):
     for pattern in patterns:

--- a/tools/fsutil.py
+++ b/tools/fsutil.py
@@ -119,14 +119,14 @@ class Filesystem(UserList):
         dir_len = sum(align(8 + len(entry.name) + 1, 2) for entry in self.data)
 
         # Calculate starting position of files in the file system image
-        files_pos = align(dir_len) + 2 * SECTOR
+        files_pos = align(dir_len)
 
         with open(path, 'wb') as fh:
             # Write directory header
             fh.write(pack('>H', dir_len))
             # Write directory entries
             for entry in self.data:
-                start = sectors(entry.offset)
+                start = sectors(entry.offset + files_pos)
                 reclen = align(8 + len(entry.name) + 1, 2)
                 name = entry.name.encode('ascii') + b'\0'
                 fh.write(pack('>BBHI%ds' % len(name),

--- a/tools/romutil.py
+++ b/tools/romutil.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+
+import argparse
+import os
+from array import array
+from struct import pack
+from io import BytesIO
+
+from fsutil import SECTOR, write_pad, Filesystem
+
+#
+# In memory format description:
+#
+# sector 0..1: boot code
+#  [LONG] initial stack pointer
+#  [LONG] initial program counter
+#  [LONG] size of executable file aligned to sector size (takes m sectors)
+#  ...    boot code
+#
+# sector 2..: file system image
+
+ROMADDR = 0xf80000
+ROMSIZE = 0x080000
+
+
+def romcode(path):
+    if not os.path.isfile(path):
+        return None
+    with open(path, 'rb') as fh:
+        romcode = fh.read()
+    if len(romcode) > 2 * SECTOR:
+        raise SystemExit('ROM startup code is larger than 1024 bytes!')
+    return romcode
+
+
+def find_exec(img):
+    with open(img, 'rb') as fs:
+        for entry in Filesystem.load(fs):
+            if entry.exe:
+                return entry
+
+    return None
+
+
+def write_startup(rom, startup, exe):
+    startup = BytesIO(startup)
+    # Overwrite rom startup hunk file setup
+    startup.seek(8, os.SEEK_SET)
+    startup.write(pack('>II', exe.offset + 2 * SECTOR + ROMADDR, exe.size))
+    # Move to the end and pad it so it takes 2 sectors
+    startup.seek(0, os.SEEK_END)
+    write_pad(startup, 2 * SECTOR)
+    # Write fixed boot block to file system image
+    rom.write(startup.getvalue())
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description='Create ROM file from file system image.')
+    parser.add_argument(
+        'startup', metavar='STARTUP', type=str,
+        help='ROM startup code')
+    parser.add_argument(
+        'image', metavar='IMAGE', type=str,
+        help='File system image file')
+    parser.add_argument(
+        'rom', metavar='ROM', type=str,
+        help='ROM output file')
+    args = parser.parse_args()
+
+    startup = romcode(args.startup)
+    if not startup:
+        raise SystemExit('ROM startup code file does not exists!')
+    executable = find_exec(args.image)
+    if not executable:
+        raise SystemExit('No AmigaHunk executable found!')
+
+    with open(args.rom, 'wb') as rom:
+        write_startup(rom, startup, executable)
+
+        # Write file system image
+        with open(args.image, 'rb') as img:
+            rom.write(img.read())
+
+        # Complete ROM disk image
+        write_pad(rom, ROMSIZE)
+
+        # Write footer
+        rom.seek(-16, os.SEEK_END)
+        rom.write(bytes.fromhex('471848194f1a531b541c4f1d571e4e1f'))


### PR DESCRIPTION
The read only-filesystem created with `fsutil.py` is needed to deploy any effect or whole demo in three forms:
 * a floppy image – possibly using custom track format,
 * AmigaHunk executable – for those that wish to run demo from harddisk under AmigaOS control,
 * ROM images – mainly for debugging purposes, to speed up effect / demo loading.

Thus I need a set of tools:
 * `fsutil.py` – takes files and puts them into a filesystem image `fs.img`
 * `adfutil.py` – takes `fs.img` and `bootblock.asm` code, encodes them into ADF format
 * `romutil.py` – takes `fs.img` and `a500rom.asm` code, encodes them into ROM image

Secondly I need to provide an abstraction that will be able to read files from the filesystem no matter if it's loaded into ROM or RAM memory, or is stored on floppy disk.