### PR TITLE
Make the filesystem oblivious to device it reads from

### DIFF
--- a/a500rom.asm
+++ b/a500rom.asm
@@ -57,7 +57,8 @@ Setup:
 
         clr.l   BD_HUNK(a6)
         clr.l   BD_VBR(a6)
-        clr.w   BD_CPUMODEL(a6)
+        move.b  #1,BD_BOOTDEV(a6)
+        clr.b   BD_CPUMODEL(a6)
         move.w  #2,BD_NREGIONS(a6)
 
         lea     BD_REGION(a6),a0

--- a/bootloader.asm
+++ b/bootloader.asm
@@ -69,7 +69,8 @@ _LVOCacheControl        EQU     -648
         APTR    BD_VBR
         APTR    BD_STKBOT
         LONG    BD_STKSZ
-        WORD    BD_CPUMODEL
+        BYTE    BD_BOOTDEV
+        BYTE    BD_CPUMODEL
         WORD    BD_NREGIONS
         LABEL   BD_REGION
         LABEL   BD_SIZE
@@ -177,10 +178,11 @@ KillOS:
         ; BOOTDATA structure above is placed just after the end of boot loader.
 
         ; [a2] boot loader data
-        lea     BD_CPUMODEL(a2),a3
+        lea     BD_BOOTDEV(a2),a3
 
-        ; save processor model
+        ; start from floppy drive
         clr.b   (a3)+
+        ; save processor model
         move.b  AttnFlags+1(a6),(a3)+
 
         ; save memory regions
@@ -235,7 +237,7 @@ Start:
         clr.l   d0
 
         ; relocate exception vector if cpu has VBR register (68010 or later)
-        tst.w   BD_CPUMODEL(a6)
+        tst.b   BD_CPUMODEL(a6)
         beq.b   .novbr
 
         ; if two regions or more we have fast memory

--- a/include/common.h
+++ b/include/common.h
@@ -112,7 +112,7 @@ static inline int mul16(short a, short b) {
   asm("divs %3,%0\n"                                                           \
       "move.w %0,%1\n"                                                         \
       "swap %0\n"                                                              \
-      : "=d" (_q), "=d" (_r)                                                   \
+      : "=d" (_r), "=d" (_q)                                                   \
       : "0" (_n), "d" (_d));
 
 static inline void bclr(u_char *ptr, char bit) {

--- a/include/system/boot.h
+++ b/include/system/boot.h
@@ -16,7 +16,8 @@ typedef struct BootData {
   void *bd_vbr;         /* Vector Base Register (for 68010+) */
   void *bd_stkbot;      /* Stack bottom pointer */
   u_int bd_stksz;       /* Stack size */
-  u_short bd_cpumodel;  /* Processor model */
+  u_char bd_bootdev;    /* 0=floppy, 1=rom/baremetal, 2=ram/amigaos */
+  u_char bd_cpumodel;   /* Processor model */
   u_short bd_nregions;  /* Number of memory regions */
   MemRegionT bd_region[0];
 } BootDataT;

--- a/include/system/file.h
+++ b/include/system/file.h
@@ -34,7 +34,7 @@ void FilePutChar(FileT *f, char c);
 int FileGetChar(FileT *f);
 void FilePrintf(FileT *f, const char *fmt, ...);
 
-FileT *MemoryOpen(const void *buf, u_int nbyte);
+FileT *MemOpen(const void *buf, u_int nbyte);
 FileT *SerialOpen(u_int baud, u_int flags);
 
 #endif

--- a/include/system/filesys.h
+++ b/include/system/filesys.h
@@ -9,7 +9,7 @@ struct File *OpenFile(const char *path);
 int GetFileSize(const char *path);
 void *LoadFile(const char *path, u_int memoryFlags);
 
-void InitFileSys(void);
+void InitFileSys(struct File *dev);
 void KillFileSys(void);
 
 #endif

--- a/include/system/floppy.h
+++ b/include/system/floppy.h
@@ -1,17 +1,14 @@
-#ifndef __FLOPPY_H__
-#define __FLOPPY_H__
+#ifndef __SYSTEM_FLOPPY_H__
+#define __SYSTEM_FLOPPY_H__
 
-#include "common.h"
+struct File;
 
-#define TRACK_SIZE 12800
-#define TD_SECTOR 512
+#define RAW_TRACK_SIZE 12800
+#define SECTOR_SIZE 512
 #define NSECTORS 11
 #define NTRACKS 160
+#define TRACK_SIZE (NSECTORS * SECTOR_SIZE)
 
-void InitFloppy(void);
-void KillFloppy(void);
+struct File *FloppyOpen(void);
 
-void FloppyTrackRead(short num);
-void FloppyTrackDecode(u_int *buf);
-
-#endif
+#endif /* !__SYSTEM_FLOPPY__ */

--- a/lib/libgfx/CpuEdge.c
+++ b/lib/libgfx/CpuEdge.c
@@ -38,7 +38,7 @@ void CpuEdge(short xs asm("d0"), short ys asm("d1"),
     di = 0;
     df = adx;
   } else {
-    divmod16(adx, dy, df, di);
+    divmod16(adx, dy, di, df);
   }
 
   xi = ~xs & 7;

--- a/system/amigaos.c
+++ b/system/amigaos.c
@@ -48,6 +48,7 @@ static __aligned(4) char FastMem[512 * 1024];
 static BootDataT BootData = {
   .bd_hunk = NULL,
   .bd_vbr = NULL,
+  .bd_bootdev = 2,
   .bd_cpumodel = CPU_68000,
   .bd_stkbot = NULL,
   .bd_stksz = 0,

--- a/system/drivers/filesys.c
+++ b/system/drivers/filesys.c
@@ -1,4 +1,5 @@
 #include <debug.h>
+#include <common.h>
 #include <string.h>
 #include <types.h>
 #include <system/errno.h>

--- a/system/drivers/floppy.c
+++ b/system/drivers/floppy.c
@@ -155,7 +155,7 @@ static void FloppyTrackRead(FileT *f, short num) {
   ClearIRQ(INTF_DSKBLK);
   EnableDMA(DMAF_DISK);
 
-  Debug("[Floppy] Read track %d.\n", num);
+  Debug("Read track %d", num);
 
   custom->dskpt = (void *)f->encoded;
   /* Write track size twice to initiate DMA transfer. */
@@ -204,7 +204,7 @@ static void FloppyTrackDecode(FileT *f) {
 
     *(u_int *)&info = DecodeLong(sector->info[0], sector->info[1], mask);
 
-    Debug("[Floppy] Decode: sector=%p, #sector=%d, #track=%d\n",
+    Debug("sector=%p, #sector=%d, #track=%d",
           sector, info.sectorNum, info.trackNum);
     Assume(info.sectorNum < NSECTORS && info.trackNum < NTRACKS);
 
@@ -300,7 +300,7 @@ static int FloppyRead(FileT *f, void *buf, u_int nbyte) {
   Assume(f != NULL);
   Assume(f->pos >= 0 && f->pos <= FLOPPY_SIZE);
 
-  Log("[FloppyRead] $%p $%p %d+%d\n", f, buf, f->pos, nbyte);
+  Debug("$%p $%p %d+%d", f, buf, f->pos, nbyte);
 
   left = min(left, FLOPPY_SIZE - f->pos);
 

--- a/system/drivers/floppy.c
+++ b/system/drivers/floppy.c
@@ -1,4 +1,5 @@
 #include <custom.h>
+#include <common.h>
 #include <debug.h>
 #include <string.h>
 #include <system/cia.h>

--- a/system/drivers/floppy.c
+++ b/system/drivers/floppy.c
@@ -1,9 +1,13 @@
 #include <custom.h>
 #include <debug.h>
+#include <string.h>
 #include <system/cia.h>
+#include <system/errno.h>
 #include <system/floppy.h>
+#include <system/file.h>
 #include <system/interrupt.h>
 #include <system/memory.h>
+#include <system/mutex.h>
 #include <system/task.h>
 #include <system/timer.h>
 
@@ -13,26 +17,28 @@
 #define OUTWARDS 0
 #define INWARDS  1
 
+#define FLOPPY_SIZE (SECTOR_SIZE * NSECTORS * NTRACKS)
+
 /*
  * Amiga MFM track format:
  * http://lclevy.free.fr/adflib/adf_info.html#p22
  */
 
-typedef struct {
+typedef struct SectorInfo {
   u_char format;
   u_char trackNum;
   u_char sectorNum;
   u_char gapDist;
 } SectorInfoT;
 
-typedef struct {
+typedef struct Sector {
   u_int magic;
   u_short sync[2];
   u_int info[2];
   u_int sectorLabel[2][4];
   u_int checksumHeader[2];
   u_int checksum[2];
-  u_int data[2][TD_SECTOR / sizeof(u_int)];
+  u_int data[2][SECTOR_SIZE / sizeof(u_int)];
 } SectorT;
 
 /*
@@ -44,10 +50,18 @@ typedef struct {
  * 832 bytes between the end of sector #10 and beginning of sector #0.
  */
 
-static short headDir;
-static short trackNum;
-static SectorT *track;
-static CIATimerT *fdtmr;
+struct File {
+  FileOpsT *ops;
+  int pos;
+
+  short headDir;
+  short trackNum;
+  CIATimerT *fdtmr;
+
+  short trkInBuf;
+  SectorT *encoded;
+  u_char *decoded;
+};
 
 static inline void WaitDiskReady(void) {
   while (ciaa->ciapra & CIAF_DSKRDY);
@@ -55,42 +69,42 @@ static inline void WaitDiskReady(void) {
 
 #define STEP_SETTLE TIMER_MS(3)
 
-static void StepHeads(void) {
+static void StepHeads(FileT *f) {
   u_char *ciaprb = (u_char *)&ciab->ciaprb;
 
   bclr(ciaprb, CIAB_DSKSTEP);
   bset(ciaprb, CIAB_DSKSTEP);
 
-  WaitTimerSleep(fdtmr, STEP_SETTLE);
+  WaitTimerSleep(f->fdtmr, STEP_SETTLE);
 
-  trackNum += headDir;
+  f->trackNum += f->headDir;
 }
 
 #define DIRECTION_REVERSE_SETTLE TIMER_MS(18)
 
-static void HeadsStepDirection(short inwards) {
+static void HeadsStepDirection(FileT *f, short inwards) {
   u_char *ciaprb = (u_char *)&ciab->ciaprb;
 
   if (inwards) {
     bclr(ciaprb, CIAB_DSKDIREC);
-    headDir = 2;
+    f->headDir = 2;
   } else {
     bset(ciaprb, CIAB_DSKDIREC);
-    headDir = -2;
+    f->headDir = -2;
   }
 
-  WaitTimerSleep(fdtmr, DIRECTION_REVERSE_SETTLE);
+  WaitTimerSleep(f->fdtmr, DIRECTION_REVERSE_SETTLE);
 }
 
-static inline void ChangeDiskSide(short upper) {
+static inline void ChangeDiskSide(FileT *f, short upper) {
   u_char *ciaprb = (u_char *)&ciab->ciaprb;
 
   if (upper) {
     bclr(ciaprb, CIAB_DSKSIDE);
-    trackNum++;
+    f->trackNum++;
   } else {
     bset(ciaprb, CIAB_DSKSIDE);
-    trackNum--;
+    f->trackNum--;
   }
 }
 
@@ -116,62 +130,25 @@ static void FloppyMotorOff(void) {
   bclr(ciaprb, CIAB_DSKSEL0);
 }
 
-static void DiskBlockInterrupt(__unused void *ptr) {
-  TaskNotifyISR(INTF_DSKBLK);
-}
-
-void InitFloppy(void) {
-  Log("[Floppy] Initialising driver!\n");
-
-  custom->dsksync = DSK_SYNC;
-  custom->adkcon = ADKF_SETCLR | ADKF_MFMPREC | ADKF_WORDSYNC | ADKF_FAST;
-
-  fdtmr = AcquireTimer(TIMER_CIAB_A);
-
-  DisableDMA(DMAF_DISK);
-  SetIntVector(DSKBLK, DiskBlockInterrupt, NULL);
-  ClearIRQ(INTF_DSKBLK);
-  EnableINT(INTF_DSKBLK);
-
-  track = MemAlloc(TRACK_SIZE, MEMF_CHIP);
-
-  FloppyMotorOn();
-  HeadsStepDirection(OUTWARDS);
-  while (!HeadsAtTrack0())
-    StepHeads();
-  HeadsStepDirection(INWARDS);
-  ChangeDiskSide(LOWER);
-  trackNum = -1;
-}
-
-void KillFloppy(void) {
-  FloppyMotorOff();
-  DisableINT(INTF_DSKBLK);
-  ClearIRQ(INTF_DSKBLK);
-  ResetIntVector(DSKBLK);
-  ReleaseTimer(fdtmr);
-  MemFree(track);
-}
-
 #define DISK_SETTLE TIMER_MS(15)
 
-void FloppyTrackRead(short num) {
-  if (trackNum == num)
+static void FloppyTrackRead(FileT *f, short num) {
+  if (f->trackNum == num)
     return;
 
-  if (trackNum == -1)
-    trackNum = 0;
+  if (f->trackNum == -1)
+    f->trackNum = 0;
 
-  if ((num ^ trackNum) & 1)
-    ChangeDiskSide(num & 1);
+  if ((num ^ f->trackNum) & 1)
+    ChangeDiskSide(f, num & 1);
 
-  if (num != trackNum) {
-    HeadsStepDirection(num > trackNum);
-    while (num != trackNum)
-      StepHeads();
+  if (num != f->trackNum) {
+    HeadsStepDirection(f, num > f->trackNum);
+    while (num != f->trackNum)
+      StepHeads(f);
   }
 
-  WaitTimerSleep(fdtmr, DISK_SETTLE);
+  WaitTimerSleep(f->fdtmr, DISK_SETTLE);
 
   custom->dsklen = 0; /* Make sure the DMA for the disk is turned off. */
   ClearIRQ(INTF_DSKBLK);
@@ -179,10 +156,10 @@ void FloppyTrackRead(short num) {
 
   Debug("[Floppy] Read track %d.\n", num);
 
-  custom->dskpt = (void *)track;
+  custom->dskpt = (void *)f->encoded;
   /* Write track size twice to initiate DMA transfer. */
-  custom->dsklen = DSK_DMAEN | (TRACK_SIZE / sizeof(short));
-  custom->dsklen = DSK_DMAEN | (TRACK_SIZE / sizeof(short));
+  custom->dsklen = DSK_DMAEN | (RAW_TRACK_SIZE / sizeof(short));
+  custom->dsklen = DSK_DMAEN | (RAW_TRACK_SIZE / sizeof(short));
 
   TaskWait(INTF_DSKBLK);
 
@@ -208,9 +185,10 @@ static SectorT *FindSectorHeader(void *ptr) {
   return HeaderToSector(data);
 }
 
-void FloppyTrackDecode(u_int *buf) {
+static void FloppyTrackDecode(FileT *f) {
   register u_int mask asm("d7") = 0x55555555;
-  u_short *data = (u_short *)track;
+  u_short *data = (u_short *)f->encoded;
+  u_int *buf = (u_int *)f->decoded;
   SectorT *sector;
   short secnum = NSECTORS;
 
@@ -231,10 +209,10 @@ void FloppyTrackDecode(u_int *buf) {
 
     /* Decode sector! */
     {
-      u_int *dst = (void *)buf + info.sectorNum * TD_SECTOR;
+      u_int *dst = (void *)buf + info.sectorNum * SECTOR_SIZE;
       u_int *odd = sector->data[0];
       u_int *even = sector->data[1];
-      short n = TD_SECTOR / sizeof(u_int) / 2 - 1;
+      short n = SECTOR_SIZE / sizeof(u_int) / 2 - 1;
 
       do {
         *dst++ = DecodeLong(*odd++, *even++, mask);
@@ -249,4 +227,128 @@ void FloppyTrackDecode(u_int *buf) {
     if (info.gapDist == 1 && secnum > 1)
       sector = FindSectorHeader(sector);
   } while (--secnum);
+}
+
+static void DiskBlockInterrupt(__unused void *ptr) {
+  TaskNotifyISR(INTF_DSKBLK);
+}
+
+static int FloppyRead(FileT *f, void *buf, u_int nbyte);
+static int FloppySeek(FileT *f, int offset, int whence);
+static void FloppyClose(FileT *f);
+
+static FileOpsT FloppyOps = {
+  .read = FloppyRead,
+  .write = NULL,
+  .seek = FloppySeek,
+  .close = FloppyClose,
+};
+
+static MUTEX(FloppyMtx);
+
+FileT *FloppyOpen(void) {
+  static FileT *f = NULL;
+
+  MutexLock(&FloppyMtx);
+
+  if (f == NULL) {
+    Log("[Floppy] Initialising driver!\n");
+
+    f = MemAlloc(sizeof(FileT), MEMF_PUBLIC|MEMF_CLEAR);
+    f->ops = &FloppyOps;
+    f->fdtmr = AcquireTimer(TIMER_CIAB_A);
+    f->encoded = MemAlloc(RAW_TRACK_SIZE, MEMF_CHIP);
+    f->decoded = MemAlloc(TRACK_SIZE, MEMF_PUBLIC);
+
+    custom->dsksync = DSK_SYNC;
+    custom->adkcon = ADKF_SETCLR | ADKF_MFMPREC | ADKF_WORDSYNC | ADKF_FAST;
+
+    DisableDMA(DMAF_DISK);
+    SetIntVector(DSKBLK, DiskBlockInterrupt, NULL);
+    ClearIRQ(INTF_DSKBLK);
+    EnableINT(INTF_DSKBLK);
+
+    FloppyMotorOn();
+    HeadsStepDirection(f, OUTWARDS);
+    while (!HeadsAtTrack0())
+      StepHeads(f);
+    HeadsStepDirection(f, INWARDS);
+    ChangeDiskSide(f, LOWER);
+    f->trackNum = -1;
+    f->trkInBuf = -1;
+  }
+
+  MutexUnlock(&FloppyMtx);
+
+  return f;
+}
+
+static void FloppyClose(FileT *f) {
+  FloppyMotorOff();
+  DisableINT(INTF_DSKBLK);
+  ClearIRQ(INTF_DSKBLK);
+  ResetIntVector(DSKBLK);
+  ReleaseTimer(f->fdtmr);
+  MemFree(f->encoded);
+  MemFree(f);
+}
+
+static int FloppyRead(FileT *f, void *buf, u_int nbyte) {
+  int left = nbyte;
+
+  Assume(f != NULL);
+  Assume(f->pos >= 0 && f->pos <= FLOPPY_SIZE);
+
+  Log("[FloppyRead] $%p $%p %d+%d\n", f, buf, f->pos, nbyte);
+
+  left = min(left, FLOPPY_SIZE - f->pos);
+
+  while (left > 0) {
+    short trknum, trkoff;
+    int size;
+
+    divmod16(f->pos, TRACK_SIZE, trknum, trkoff);
+
+    if (trknum >= NTRACKS)
+      break;
+
+    if (trknum != f->trkInBuf) {
+      FloppyTrackRead(f, trknum);
+      FloppyTrackDecode(f);
+      f->trkInBuf = trknum;
+    }
+
+    /* Read to the end of track or less. */
+    size = min(left, TRACK_SIZE - trkoff);
+
+    memcpy(buf, f->decoded + trkoff, size);
+
+    left -= size;
+    f->pos += size;
+  }
+  
+  return nbyte - left; /* how much did we read? */
+}
+
+static int FloppySeek(FileT *f, int offset, int whence) {
+  if (whence == SEEK_CUR) {
+    offset += f->pos;
+    whence = SEEK_SET;
+  }
+
+  if (whence == SEEK_END) {
+    offset = FLOPPY_SIZE + offset;
+    whence = SEEK_SET;
+  }
+
+  if (whence == SEEK_SET) {
+    /* New position is not within file. */
+    if ((offset < 0) || (offset > FLOPPY_SIZE))
+      return EINVAL;
+
+    f->pos = offset;
+    return offset;
+  }
+
+  return EINVAL;
 }

--- a/system/drivers/memory-file.c
+++ b/system/drivers/memory-file.c
@@ -1,3 +1,4 @@
+#include <debug.h>
 #include <string.h>
 #include <system/errno.h>
 #include <system/file.h>
@@ -37,6 +38,8 @@ static void MemClose(FileT *f) {
 static int MemRead(FileT *f, void *buf, u_int nbyte) {
   int start = f->offset;
   int nread = nbyte;
+
+  Debug("$%p $%p %d+%d", f, buf, f->offset, nbyte);
 
   if (start + nread > f->length)
     nread = f->length - start;

--- a/system/kernel/amigahunk.c
+++ b/system/kernel/amigahunk.c
@@ -1,11 +1,10 @@
+#include <debug.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <strings.h>
 #include <system/amigahunk.h>
 #include <system/file.h>
 #include <system/memory.h>
-
-#define DEBUG 0
 
 #define HUNK_CODE 1001
 #define HUNK_DATA 1002
@@ -70,7 +69,6 @@ static bool LoadHunks(FileT *fh, HunkT **hunkArray) {
       n = ReadLong(fh);
       if (hunkId != HUNK_BSS)
         FileRead(fh, hunk->data, n * sizeof(int));
-#if DEBUG
       {
         const char *hunkType;
 
@@ -81,9 +79,8 @@ static bool LoadHunks(FileT *fh, HunkT **hunkArray) {
         else
           hunkType = " BSS";
 
-        printf("%s: %p - %p\n", hunkType, hunk->data, hunk->data + hunk->size);
+        Debug("%s: %p - %p", hunkType, hunk->data, hunk->data + hunk->size);
       }
-#endif
     } else if (hunkId == HUNK_DEBUG) {
       n = ReadLong(fh);
       SkipLongs(fh, n);
@@ -106,9 +103,7 @@ static bool LoadHunks(FileT *fh, HunkT **hunkArray) {
         hunk = hunkArray[hunkIndex++];
       }
     } else {
-#if DEBUG
-      printf("Unknown hunk $%04x!\n", hunkCode);
-#endif
+      Debug("Unknown hunk $%04x!", hunkId);
       return false;
     }
   }
@@ -121,8 +116,10 @@ HunkT *LoadHunkList(FileT *fh) {
   int n, first, last, hunkCount;
   HunkT **hunkArray;
 
-  if (hunkId != HUNK_HEADER)
+  if (hunkId != HUNK_HEADER) {
+    Log("Not an Amiga Hunk file!\n");
     return NULL;
+  }
 
   /* Skip resident library names. */
   while ((n = ReadLong(fh)))

--- a/system/kernel/amigahunk.c
+++ b/system/kernel/amigahunk.c
@@ -79,7 +79,7 @@ static bool LoadHunks(FileT *fh, HunkT **hunkArray) {
         else
           hunkType = " BSS";
 
-        Debug("%s: %p - %p", hunkType, hunk->data, hunk->data + hunk->size);
+        Log("%s: %p - %p\n", hunkType, hunk->data, hunk->data + hunk->size);
       }
     } else if (hunkId == HUNK_DEBUG) {
       n = ReadLong(fh);
@@ -103,7 +103,7 @@ static bool LoadHunks(FileT *fh, HunkT **hunkArray) {
         hunk = hunkArray[hunkIndex++];
       }
     } else {
-      Debug("Unknown hunk $%04x!", hunkId);
+      Log("Unknown hunk $%04x!\n", hunkId);
       return false;
     }
   }

--- a/system/loader.c
+++ b/system/loader.c
@@ -8,6 +8,7 @@
 #include <system/exception.h>
 #include <system/filesys.h>
 #include <system/file.h>
+#include <system/floppy.h>
 #include <system/interrupt.h>
 #include <system/memory.h>
 #include <system/task.h>

--- a/system/loader.c
+++ b/system/loader.c
@@ -72,7 +72,14 @@ void Loader(BootDataT *bd) {
 
   TaskInit(CurrentTask, "main", bd->bd_stkbot, bd->bd_stksz);
 #ifdef TRACKMO
-  InitFileSys(FloppyOpen());
+  {
+    FileT *dev;
+    if (bd->bd_bootdev)
+      dev = MemOpen((const void *)0xf80000, 0x80000);
+    else
+      dev = FloppyOpen();
+    InitFileSys(dev);
+  }
 #endif
   CallFuncList(&__INIT_LIST__);
 

--- a/system/loader.c
+++ b/system/loader.c
@@ -7,7 +7,7 @@
 #include <system/cpu.h>
 #include <system/exception.h>
 #include <system/filesys.h>
-#include <system/floppy.h>
+#include <system/file.h>
 #include <system/interrupt.h>
 #include <system/memory.h>
 #include <system/task.h>
@@ -71,8 +71,7 @@ void Loader(BootDataT *bd) {
 
   TaskInit(CurrentTask, "main", bd->bd_stkbot, bd->bd_stksz);
 #ifdef TRACKMO
-  InitFloppy();
-  InitFileSys();
+  InitFileSys(FloppyOpen());
 #endif
   CallFuncList(&__INIT_LIST__);
 
@@ -84,7 +83,6 @@ void Loader(BootDataT *bd) {
   CallFuncList(&__EXIT_LIST__);
 #ifdef TRACKMO
   KillFileSys();
-  KillFloppy();
 #endif
   
   Log("[Loader] Shutdown complete!\n");


### PR DESCRIPTION
We're going to embed filesystem in:
 * ROM for debugging, 
 * RAM when starting from AmigaOS,
 * FLOPPY when starting from bootblock.

Thus the implementation of file system must not be dependant on specific source.
So the filesystem now can be initialized from file created with `FloppyOpen` or `MemOpen`.